### PR TITLE
delete ListenerBeanFactoryInitializationAotProcessor @Bean injection

### DIFF
--- a/src/main/java/com/example/aot/bfpp/BfppConfiguration.java
+++ b/src/main/java/com/example/aot/bfpp/BfppConfiguration.java
@@ -32,11 +32,6 @@ class BfppConfiguration {
 		return new ListenerBeanFactoryPostProcessor();
 	}
 
-	@Bean
-	static ListenerBeanFactoryInitializationAotProcessor listenerBeanFactoryInitializationAotProcessor() {
-		return new ListenerBeanFactoryInitializationAotProcessor();
-	}
-
 }
 
 // <3>


### PR DESCRIPTION
ListenerBeanFactoryInitializationAotProcessor was defined in the aot.factories file, the @Bean injection is unnecessary.